### PR TITLE
게시글 삭제, 수정 시 로직 작성

### DIFF
--- a/src/main/java/club/inq/team1/repository/post/ImageRepository.java
+++ b/src/main/java/club/inq/team1/repository/post/ImageRepository.java
@@ -1,9 +1,12 @@
 package club.inq.team1.repository.post;
 
 import club.inq.team1.entity.Image;
+import club.inq.team1.entity.Post;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
+    List<Image> findByPost(Post post);
 }

--- a/src/main/java/club/inq/team1/service/impl/post/ImageServiceImpl.java
+++ b/src/main/java/club/inq/team1/service/impl/post/ImageServiceImpl.java
@@ -8,6 +8,7 @@ import club.inq.team1.repository.post.ImageRepository;
 import club.inq.team1.service.post.ImageService;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,5 +67,22 @@ public class ImageServiceImpl implements ImageService {
         return saved;
     }
 
+    @Override
+    @Transactional
+    public void deleteImages(Post post) {
+        List<Image> images = imageRepository.findByPost(post);
 
+        // 실제 파일 시스템에서 이미지 파일 삭제
+        for (Image image : images) {
+            String imagePath = image.getImagePath();
+            Path filePath = Path.of("C:/images/" + imagePath);
+            System.out.println(imagePath);
+            // 실제 파일 삭제
+            try {
+                Files.deleteIfExists(filePath);
+            } catch (IOException e) {
+                throw new RuntimeException("이미지 파일 삭제과정에서 문제가 발생했습니다.", e);
+            }
+        }
+    }
 }

--- a/src/main/java/club/inq/team1/service/impl/post/ImageServiceImpl.java
+++ b/src/main/java/club/inq/team1/service/impl/post/ImageServiceImpl.java
@@ -80,6 +80,9 @@ public class ImageServiceImpl implements ImageService {
             // 실제 파일 삭제
             try {
                 Files.deleteIfExists(filePath);
+                if(imageRepository.findById(image.getImageId()).isPresent()) {
+                    imageRepository.deleteById(image.getImageId());
+                }
             } catch (IOException e) {
                 throw new RuntimeException("이미지 파일 삭제과정에서 문제가 발생했습니다.", e);
             }

--- a/src/main/java/club/inq/team1/service/impl/post/PostServiceImpl.java
+++ b/src/main/java/club/inq/team1/service/impl/post/PostServiceImpl.java
@@ -73,6 +73,12 @@ public class PostServiceImpl implements PostService {
 
         postRepository.save(post);
 
+
+        if(multipartFiles != null){
+            imageService.deleteImages(post);
+            imageService.saveWithPost(multipartFiles, post);
+        }
+
         return true;
     }
 

--- a/src/main/java/club/inq/team1/service/impl/post/PostServiceImpl.java
+++ b/src/main/java/club/inq/team1/service/impl/post/PostServiceImpl.java
@@ -86,6 +86,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    @Transactional
     public Boolean deletePost(Long postId) {
         Post post = postRepository.findById(postId).orElseThrow();
         User user = currentUser.get();

--- a/src/main/java/club/inq/team1/service/impl/post/PostServiceImpl.java
+++ b/src/main/java/club/inq/team1/service/impl/post/PostServiceImpl.java
@@ -74,10 +74,10 @@ public class PostServiceImpl implements PostService {
         postRepository.save(post);
 
 
-        if(multipartFiles != null){
-            imageService.deleteImages(post);
-            imageService.saveWithPost(multipartFiles, post);
-        }
+//        if(multipartFiles != null){
+//            imageService.deleteImages(post);
+//            imageService.saveWithPost(multipartFiles, post);
+//        }
 
         return true;
     }

--- a/src/main/java/club/inq/team1/service/impl/post/PostServiceImpl.java
+++ b/src/main/java/club/inq/team1/service/impl/post/PostServiceImpl.java
@@ -8,6 +8,7 @@ import club.inq.team1.entity.Image;
 import club.inq.team1.entity.Post;
 import club.inq.team1.entity.PostLike;
 import club.inq.team1.entity.User;
+import club.inq.team1.repository.post.ImageRepository;
 import club.inq.team1.repository.post.PostRepository;
 import club.inq.team1.repository.post.PostLikeRepository;
 import club.inq.team1.service.MapService;
@@ -35,6 +36,7 @@ public class PostServiceImpl implements PostService {
     private final ImageService imageService;
     private final CommentService commentService;
     private final MapService naverMapService;
+    private final ImageRepository imageRepository;
 
     @Override
     @Transactional
@@ -93,6 +95,7 @@ public class PostServiceImpl implements PostService {
         }
 
         // 게시글 관련 정보 지워야됨. 댓글은 알아서 지워지는데 답글은 안지워짐 이미지 정보도 지워지는데 이미지 파일은 안지워짐
+        imageService.deleteImages(post);
         postRepository.delete(post);
 
         return true;

--- a/src/main/java/club/inq/team1/service/post/ImageService.java
+++ b/src/main/java/club/inq/team1/service/post/ImageService.java
@@ -10,4 +10,6 @@ public interface ImageService {
     ResponseImageDTO toResponseImageDTO(Image image);
 
     List<Image> saveWithPost(List<MultipartFile> file, Post post);
+
+    void deleteImages(Post post);
 }


### PR DESCRIPTION
**✅ 게시글 삭제 시 실제 저장된 이미지도 같이 삭제됩니다.**

**✅ 게시글 수정 시 변경된 이미지가 있다면 기존 이미지들을 삭제 후 새 이미지들로 저장**
-> 일단 service 내에서 multipleFile 이 새로운 이미지를 나타내는 것 같아 활용해서 로직을 작성했는데 고쳐야한다면 말씀해주세요

**✅ 게시글 삭제 시 답글도 삭제되도록 수정했습니다.**